### PR TITLE
Bug fixed

### DIFF
--- a/middlewares/adminMiddleware.js
+++ b/middlewares/adminMiddleware.js
@@ -15,7 +15,7 @@ module.exports = function(req, res, next) {
       Email: req.user.email
     }
   }).then(function(data) {
-    if(data.length === 1) {
+    if(data.length) {
       next();
     }
     else {


### PR DESCRIPTION
When one coordinator was coordinating multiple events, not authorized
reponse was send, because coordinator's event count was check against 1