### PR TITLE
Create team API now returns team ID

### DIFF
--- a/lib/api/User2/Teams/teamCrud.js
+++ b/lib/api/User2/Teams/teamCrud.js
@@ -73,7 +73,10 @@ router.post('/', function(req, res, next){
     CurrentRound: 0
   }).then(function(data) {
     r.status = statusCodes.SUCCESS;
-    r.data = "Team created Successfully";
+    r.status.message = "Team created successfully";
+    r.data = {
+      Id: data.Id,
+    };
     res.json(r);
   }).catch(function(err) {
       r.status = statusCodes.SERVER_ERROR;


### PR DESCRIPTION
Fixed a bug,

Previously, creating a team didn't return the ID of created team.